### PR TITLE
build and validate updated

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -28,6 +28,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 jobs:
   build-and-publish:
@@ -46,7 +47,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '24'
         registry-url: 'https://registry.npmjs.org'
         cache: 'npm'
 
@@ -242,42 +243,35 @@ jobs:
     - name: Publish to NPM
       id: publish
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         REGISTRY_TARGET="${{ github.event.inputs.registry_target || 'npmjs' }}"
         PUBLISHED="false"
-        
+
         echo "🚀 Publishing package to $REGISTRY_TARGET..."
-        
+
         publish_to_npmjs() {
-          echo "📦 Publishing to NPM.js..."
-          
-          if [ -z "$NODE_AUTH_TOKEN" ]; then
-            echo "❌ Error: NPM_TOKEN secret is not configured"
-            return 1
-          fi
-          
+          echo "📦 Publishing to NPM.js (OIDC)..."
+
           npm config delete registry || true
           npm config delete //npm.pkg.github.com/:_authToken || true
           npm config set registry https://registry.npmjs.org/
-          npm config set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
-          
+
           if [ -f package.json.backup ]; then
             cp package.json.backup package.json
           else
             cp package.json package.json.backup
           fi
-          
+
           jq 'del(.publishConfig)' package.json > package.json.tmp && mv package.json.tmp package.json
-          
+
           FORCE_FLAG=""
           if [ "${{ github.event.inputs.force_publish }}" == "true" ]; then
             echo "⚠️  Force publish enabled"
             FORCE_FLAG="--force"
           fi
-          
-          if npm publish $FORCE_FLAG --access public --registry https://registry.npmjs.org/; then
+
+          if npm publish $FORCE_FLAG --provenance --access public --registry https://registry.npmjs.org/; then
             echo "✅ Successfully published to NPM.js"
             return 0
           else

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,12 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "@burgan-tech/vnext-schema": "^0.0.23"
-      },
       "bin": {
         "vnext-setup": "setup.js",
         "vnext-template": "init.js"
       },
       "devDependencies": {
-        "@burgan-tech/vnext-schema": "^0.0.23",
+        "@burgan-tech/vnext-schema": "^0.0.38",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1"
       },
@@ -26,9 +23,9 @@
       }
     },
     "node_modules/@burgan-tech/vnext-schema": {
-      "version": "0.0.23",
-      "resolved": "https://registry.npmjs.org/@burgan-tech/vnext-schema/-/vnext-schema-0.0.23.tgz",
-      "integrity": "sha512-lXJot5DP35p+HQ/0yTYW6CXH1fhVCcosu8NhrI30Do6uG9JazszuytrN0B4ApdyPe9EakoQ1sTK5R1sz60ZqqA==",
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@burgan-tech/vnext-schema/-/vnext-schema-0.0.38.tgz",
+      "integrity": "sha512-Lqrl5IjLVbJTirBSEK5w806PXjEJm6f/fR9rmvOMFkmvIII5vgFwKsL1cvfi28TIKp7UKwx/7vDZy71PQakyfA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -59,10 +59,11 @@
     "node": ">=16.0.0"
   },
   "devDependencies": {
-    "@burgan-tech/vnext-schema": "^0.0.23",
+    "@burgan-tech/vnext-schema": "^0.0.38",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1"
   },
   "dependencies": {
+    "@burgan-tech/vnext-schema": "^0.0.38"
   }
 }

--- a/validate.js
+++ b/validate.js
@@ -2,7 +2,8 @@
 
 const fs = require('fs');
 const path = require('path');
-const Ajv = require('ajv');
+const Ajv7 = require('ajv');
+const Ajv2019 = require('ajv/dist/2019');
 const addFormats = require('ajv-formats');
 
 // ANSI color codes for terminal output
@@ -652,13 +653,18 @@ validate('JSON files schema validation using @burgan-tech/vnext-schema', () => {
     return true;
   }
 
-  // Initialize AJV with formats support
-  const ajv = new Ajv({
-    strict: false, // Allow unknown keywords like enumDescriptions
-    allErrors: true, // Collect all errors
-    verbose: true // Include schema path in errors
-  });
-  addFormats(ajv);
+  // Initialize AJV instances for draft-07 and draft 2019-09
+  const ajv7 = new Ajv7({ strict: false, allErrors: true, verbose: true });
+  addFormats(ajv7);
+
+  const ajv2019 = new Ajv2019({ strict: false, allErrors: true, verbose: true });
+  addFormats(ajv2019);
+
+  // Pick the correct AJV instance based on the schema's $schema field
+  function getAjvInstance(schema) {
+    const draft = schema?.$schema || '';
+    return draft.includes('2019-09') ? ajv2019 : ajv7;
+  }
 
   // Map directory names to schema types dynamically from paths config
   const directoryToSchemaType = {
@@ -681,7 +687,7 @@ validate('JSON files schema validation using @burgan-tech/vnext-schema', () => {
         const schema = vnextSchema.getSchema ? vnextSchema.getSchema(schemaType) : null;
         if (schema) {
           validators[dirName] = {
-            validator: ajv.compile(schema),
+            validator: getAjvInstance(schema).compile(schema),
             type: schemaType
           };
         }

--- a/vnext.config.json
+++ b/vnext.config.json
@@ -2,8 +2,8 @@
   "version": "1.0.0",
   "description": "{domainName} Domain Definition Configuration",
   "domain": "{domainName}",
-  "runtimeVersion": "0.0.21",
-  "schemaVersion": "0.0.23",
+  "runtimeVersion": "0.0.42",
+  "schemaVersion": "0.0.38",
   "paths": {
     "componentsRoot": "{domainName}",
     "tasks": "Tasks",


### PR DESCRIPTION
## Summary by Sourcery

Update the build workflow and JSON validation tooling to support Node 24, OIDC-based npm publishing with provenance, and newer vnext schema drafts.

Enhancements:
- Upgrade @burgan-tech/vnext-schema to a newer version and add it as a runtime dependency.
- Extend the validation script to support both JSON Schema draft-07 and 2019-09 using separate AJV instances selected via the schema's $schema field.

Build:
- Grant id-token permissions in the build-and-publish GitHub Actions workflow to enable OIDC authentication for npm publishing.
- Update the Node.js version used in the build-and-publish workflow from 20.x to 24.
- Switch npm publishing in the workflow to use provenance-enabled, OIDC-based authentication instead of an NPM token.